### PR TITLE
Improve sidebar layout

### DIFF
--- a/assets/collection-navigation.css
+++ b/assets/collection-navigation.css
@@ -95,7 +95,8 @@
 }
 
 .sidebar-navigation .list-menu__item-caret {
-  font-size: 16px;
+  padding-right: 6px;
+  font-size: 20px;
 }
 
 .sidebar-navigation .list-submenu .list-menu__item-caret {
@@ -122,6 +123,10 @@
   color: var(--color-primary-foreground);
 
   text-decoration: none;
+}
+
+.sidebar-navigation-menu__link--with-children {
+  font-weight: 600;
 }
 
 .sidebar-navigation-menu__item-count {
@@ -162,6 +167,14 @@
 
 .sidebar-navigation-menu__cleanstate:nth-of-type(4) {
   width: 35%;
+}
+
+.sidebar-navigation .list-menu > .list-menu__item {
+  padding: 8px 0;
+}
+
+.sidebar-navigation .list-submenu > .list-menu__item {
+  padding: 8px 0;
 }
 
 .sidebar-navigation
@@ -250,7 +263,7 @@
   .sidebar-navigation .list-menu > .list-menu__item {
     border-bottom: 1px solid var(--color-grey-light);
 
-    padding: 8px var(--horizontal-padding);
+    padding: 12px var(--horizontal-padding);
   }
 
   .sidebar-navigation .list-menu .list-submenu .list-submenu > .list-menu__item {

--- a/assets/collection-page.css
+++ b/assets/collection-page.css
@@ -9,6 +9,7 @@
 .collection-page__wrapper--with-sidebar {
   display: grid;
   grid-template-columns: 1fr;
+  padding-top: 24px;
 }
 
 .collection-page__sidebar-navigation {
@@ -20,7 +21,7 @@
   align-items: center;
   justify-content: space-between;
 
-  margin-bottom: 24px;
+  margin-bottom: 12px;
 }
 
 .collection-page__title {
@@ -70,7 +71,7 @@
 
   .collection-page__wrapper--with-sidebar {
     grid-template-columns: 220px 1fr;
-    gap: 20px;
+    gap: 40px;
   }
 }
 

--- a/assets/sidebar-navigation.css
+++ b/assets/sidebar-navigation.css
@@ -99,8 +99,8 @@
 
 .sidebar-navigation .list-menu__item-caret {
   margin-left: auto;
-
-  font-size: 14px;
+  padding-right: 6px;
+  font-size: 21px;
 }
 
 .sidebar-navigation .list-submenu .list-menu__item-caret {

--- a/snippets/collection-navigation.liquid
+++ b/snippets/collection-navigation.liquid
@@ -31,7 +31,7 @@
                     <i class="{% if current_url == url %}fa-solid fa-angle-down{%  else %}fa-regular fa-angle-down{% endif %} list-menu__item-caret"></i>
                   </label>
                 {%  endif %}
-                <a href="{{ url }}" class="sidebar-navigation-menu__link {% if current_url == url %}sidebar-navigation-menu__link--current{% endif %}">
+                <a href="{{ url }}" class="sidebar-navigation-menu__link {% if current_url == url %}sidebar-navigation-menu__link--current{% endif %} {% if collection.has_children %} sidebar-navigation-menu__link--with-children{% endif %}">
                   {{ collection.name }}
                 </a>
                 <span class="sidebar-navigation-menu__item-count">{{ collection.items_count }}</span>


### PR DESCRIPTION
Improve layout of the sidebar:

- Make caret larger
- Make nested collection titles bold
- Increase paddings

Resolves [SC-1971](https://linear.app/booqable/issue/SC-1971/improve-sidebar-styling-of-simple-store-theme)

## Before

<img width="1311" height="1200" alt="Screenshot 2025-09-23 at 17 01 10" src="https://github.com/user-attachments/assets/6304875f-c734-42a8-a338-0b3c6f737c8a" />

## After
<img width="1312" height="1208" alt="Screenshot 2025-09-23 at 17 00 37" src="https://github.com/user-attachments/assets/3e9463c8-0aa6-4c05-bf88-d577f05e5ff1" />
