### PR TITLE
Back-end sorting

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -39,24 +39,12 @@ const handleOnSelectChange = (event) => {
     window.location.href = url.href;
     return;
   }
-    
+
   window.location.href += `?sort_by=${value}`;
 };
 
-const initSelect = () => {
+const initSortingSelect = () => {
   const select = document.querySelector("#sorting");
-  const url = new URL(window.location.href);
-
-  if (!!url.searchParams.get("sort_by")) {
-    select.value = url.searchParams.get("sort_by");
-  } else {
-    // Use the default value from the shop setting if no URL parameter
-    const defaultValue = select.getAttribute("default-value");
-    if (defaultValue && defaultValue !== 'default') {
-      handleOnSelectChange({ target: { value: defaultValue } });
-    }
-  }
-
   select.addEventListener("change", handleOnSelectChange);
 };
 
@@ -148,7 +136,7 @@ const handleOpenCollectionMenu = () => {
 document.addEventListener("DOMContentLoaded", () => {
   // Initializers
   initSearch();
-  initSelect();
+  initSortingSelect();
   handleSetMobileMenuHeight();
 });
 

--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -56,9 +56,9 @@
       {% if collection.items_count > 0 %}
         <div class="sorting-select-wrapper">
           {% assign options = "default:Standard,price_each_in_cents:Price (asc),-price_each_in_cents:Price (desc),-created_at:Newest First" | split: "," %}
-          {% render 'sorting-select' options: options, default_value: shop.default_sort %}
+          {% render 'sorting-select' options: options, default_value: products_sort_order %}
         </div>
-        {% assign paginate_object = collection.items %}
+        {% assign paginate_object = items %}
         {% paginate paginate_object %}
           <div class="collection-page__items"{% if card_image_fit != blank %} style="{{- image_variables | escape -}}"{% endif %}>
             {% for item in paginate_object %}

--- a/snippets/sorting-select.liquid
+++ b/snippets/sorting-select.liquid
@@ -1,10 +1,10 @@
 {{ "sorting.css" | asset_url | stylesheet_tag }}
 
-<select id="sorting" class="sorting-select" default-value="{{ default_value }}">
+<select id="sorting" class="sorting-select">
   {% for option in options %}
     {%  assign option_parts = option | split: ":" %}
     {%  assign value = option_parts[0] %}
     {%  assign label = option_parts[1] %}
-    <option value="{{ value }}">{{ label }}</option>
+    <option value="{{ value }}" {% if value == default_value %}SELECTED{% endif %}>{{ label }}</option>
   {% endfor %}
 </select>


### PR DESCRIPTION
This is an update link to this PR https://github.com/booqable/booqable/pull/14783

Main changes are:
- Remove code that reloaded the page after setting default sort_by parameter as this is no longer necessary
- Select the default select option on the back-end
- Avoid using `collection.items` and use `items` directly as this one is correctly sorted.