### PR TITLE
Remove collection title and redirect to root on cleanstate

### DIFF
--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -41,9 +41,6 @@
     </div>
     <div class="collection-page__inner">
       <div class="collection-page__header">
-        {% if section.settings.show_collection_name %}
-          <h1 class="collection-page__title">{{ collection.name }}</h1>
-        {% endif %}
         <div class="collection-page__sidebar-navigation--mobile">
             {% render "collection-navigation", 
               collections: non_system_collections, 
@@ -106,12 +103,6 @@
     {
       "type": "header",
       "content": "Collection"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_collection_name",
-      "label": "Show collection name",
-      "default": true
     },
     {
       "type": "checkbox",

--- a/snippets/cleanstate.liquid
+++ b/snippets/cleanstate.liquid
@@ -19,7 +19,7 @@
   <h2 class="cleanstate__title">{{ section.settings.heading }}</h2>
   <p class="cleanstate__description">{{ section.settings.text }}</p>
   <a
-    href="{{ routes.all_products_collection_url }}"
+    href="{{ routes.root_url }}"
     class="bq-button bq-button--solid bq-button--size-md"
   >
     {{ section.settings.button_label }}


### PR DESCRIPTION
[Remove collection title and redirect to root on cleanstate](https://linear.app/booqable/issue/SC-1978/remove-collection-title-and-redirect-to-root-on-cleanstate)

### Before
<img width="1107" height="588" alt="Captura de pantalla 2025-09-26 a las 8 02 38" src="https://github.com/user-attachments/assets/cbbfa515-a730-443b-8cee-2167a3b527d9" />

### After
<img width="1069" height="588" alt="Captura de pantalla 2025-09-26 a las 8 02 12" src="https://github.com/user-attachments/assets/c3bfed6b-1f48-4bc8-88f1-220bd2ea04d3" />
