### PR TITLE
Fix chevrons and layout shift

### DIFF
--- a/assets/collection-navigation.css
+++ b/assets/collection-navigation.css
@@ -11,11 +11,9 @@
   transition: max-height 200ms;
 }
 
-.list-menu__item [id^="sidebar-navigation-menu-child-"]:checked + label .list-menu__item-caret,
-.list-menu__item [id^="sidebar-navigation-menu-grandchild-"]:checked + label .list-menu__item-caret {
+[id^="sidebar-navigation-menu-child-"]:checked + .list-menu__item-wrapper .list-menu__item-caret,
+[id^="sidebar-navigation-menu-grandchild-"]:checked + .list-menu__item-wrapper .list-menu__item-caret {
   transform: rotate(180deg);
-
-  transition: transform 150ms;
 }
 
 .sidebar-toggle {
@@ -95,7 +93,6 @@
 }
 
 .sidebar-navigation .list-menu__item-caret {
-  padding-right: 6px;
   font-size: 20px;
 }
 

--- a/assets/date-picker.css
+++ b/assets/date-picker.css
@@ -9,6 +9,8 @@
 
   margin: 0 auto;
   padding: 16px var(--horizontal-padding);
+
+  min-height: 108px;
 }
 
 bq-date-picker {

--- a/assets/list-menu.css
+++ b/assets/list-menu.css
@@ -19,6 +19,7 @@
 .list-menu__item-caret {
   transform: rotate(0);
 
+  transform-origin: center;
   transition: transform 150ms;
 }
 


### PR DESCRIPTION
This PR fixes two separate small issues:

# Fix chevrons rotation
Little arrow thingies in the menu were not rotated when menu is collapsed.

## Before
https://github.com/user-attachments/assets/1b973d9c-1303-4903-997d-6bd765ee3b89

## After
https://github.com/user-attachments/assets/418bc395-8bc8-4361-907a-e6d7a91e1629

# Fix layout shift
On every page load the layout would shift by 76px when period picker loads. This was causing misclicks and is generally annoying.


## Before

https://github.com/user-attachments/assets/454cfeff-fb27-406a-949a-902697bfc1b5

## After

https://github.com/user-attachments/assets/259e29db-6020-41f0-b5c5-c0ca24d25daa


