### PR TITLE
Auth: Replace section settings translations with user_t filter

### DIFF
--- a/sections/accept-invitation-form.liquid
+++ b/sections/accept-invitation-form.liquid
@@ -11,33 +11,30 @@
   {%- endif -%}
 
   {%- if success_link_url -%}
-    <a href="{{ success_link_url }}">{{ section.settings.success_link_label }}</a>
+    <a href="{{ success_link_url }}">{{ "auth.invite.success_link_label" | user_t }}</a>
   {%- endif -%}
 
   {%- if hide_form == false -%}
-    {% if section.settings.you_are_invited or section.settings.please_enter_password %}
-      <div class="account__alert account__alert--info">
-        {% if section.settings.you_are_invited %}
-          <p>
-            {{ section.settings.you_are_invited }}
-          </p>
-        {% endif %}
+    <div class="account__alert account__alert--info">
+      <p>
+        {{ "auth.invite.you_are_invited" | user_t }}
+      </p>
 
-        {% if section.settings.please_enter_password %}
-          <p>
-            {{ section.settings.please_enter_password }}
-          </p>
-        {% endif %}
-      </div>
-    {% endif %}
+      <p>
+        {{ "auth.invite.please_enter_password" | user_t }}
+      </p>
+    </div>
 
     {% form 'accept_invitation' %}
+      {%- assign password_label = "auth.fields.password" | user_t -%}
+      {%- assign password_confirmation_label = "auth.fields.password_confirmation" | user_t -%}
+      {%- assign button_accept_label = "auth.invite.accept" | user_t -%}
       {%- render 'form-password-session-pages',
           form: form,
           form_name: "accept_invitation",
-          password_label: section.settings.password_label,
-          password_confirmation_label: section.settings.password_confirmation_label,
-          button_label: section.settings.button_accept_label
+          password_label: password_label,
+          password_confirmation_label: password_confirmation_label,
+          button_label: button_accept_label
       -%}
     {% endform %}
   {%- endif -%}
@@ -49,47 +46,6 @@
     "important": true,
     "unique": true,
     "templates": ["accept-invitation"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      },
-      {
-        "id": "you_are_invited",
-        "type": "text",
-        "label": "Accept invitation title",
-        "default": "You've been invited to create an account."
-      },
-      {
-        "id": "please_enter_password",
-        "type": "text",
-        "label": "Password instructions",
-        "default": "If you want to continue, please enter your password below."
-      },
-      {
-        "id": "password_label",
-        "type": "text",
-        "label": "Password field label",
-        "default": "New password"
-      },
-      {
-        "id": "password_confirmation_label",
-        "type": "text",
-        "label": "Password confirmation field label",
-        "default": "Confirm new password"
-      },
-      {
-        "id": "button_accept_label",
-        "type": "text",
-        "label": "Accept button label",
-        "default": "Accept invite"
-      },
-      {
-        "id": "success_link_label",
-        "type": "text",
-        "label": "Success link label",
-        "default": "Continue to the store"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}

--- a/sections/activate-account.liquid
+++ b/sections/activate-account.liquid
@@ -7,15 +7,15 @@
   </div>
 
   <h3 class="account__title account__title--centered">
-    {{ section.settings.title }}
+    {{ "auth.user_confirmed" | user_t }}
   </h3>
 
   <div class="description description--centered">
-    {{ section.settings.description }}
+    {{ "auth.user_confirmed_description" | user_t }}
   </div>
 
   <a href="{{ routes.login_url }}" class="account__button account__button--primary">
-    {{ section.settings.button_login_label }}
+    {{ "auth.sign_in_button" | user_t }}
   </a>
 
 </div>
@@ -26,26 +26,6 @@
     "important": true,
     "unique": true,
     "templates": ["activate-account"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      }, {
-        "id": "title",
-        "type": "text",
-        "label": "Title",
-        "default": "Account confirmed"
-      }, {
-        "id": "description",
-        "type": "text",
-        "label": "Description",
-        "default": "Your account has been confirmed. You can now log in and continue using the website."
-      }, {
-        "id": "button_login_label",
-        "type": "text",
-        "label": "Login button label",
-        "default": "Log in"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}

--- a/sections/edit-password-form.liquid
+++ b/sections/edit-password-form.liquid
@@ -1,21 +1,22 @@
 {{ "account.css" | asset_url | stylesheet_tag }}
 
 <div class="account">
-  <h3 class="account__title">{{ section.settings.title }}</h3>
+  <h3 class="account__title">{{ "auth.recover_password.change_password" | user_t }}</h3>
 
-  {% if section.settings.description %}
-    <div class="account__divider">
-      {{ section.settings.description }}
-    </div>
-  {% endif %}
+  <div class="account__divider">
+    {{ "auth.recover_password.instructions" | user_t }}
+  </div>
 
   {% form 'edit_password' %}
+    {%- assign password_label = "auth.fields.password" | user_t -%}
+    {%- assign password_confirmation_label = "auth.fields.password_confirmation" | user_t -%}
+    {%- assign button_label = "auth.recover_password.change_password" | user_t -%}
     {%- render 'form-password-session-pages',
         form: form,
         form_name: "edit_password",
-        password_label: section.settings.password_label,
-        password_confirmation_label: section.settings.password_confirmation_label,
-        button_label: section.settings.change_my_password
+        password_label: password_label,
+        password_confirmation_label: password_confirmation_label,
+        button_label: button_label
     -%}
   {% endform %}
 </div>
@@ -26,39 +27,6 @@
     "important": true,
     "unique": true,
     "templates": ["edit-password"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      },
-      {
-        "id": "title",
-        "type": "text",
-        "label": "Title",
-        "default": "Change your password"
-      },
-      {
-        "id": "description",
-        "type": "text",
-        "label": "Description",
-        "default": ""
-      },
-      {
-        "id": "password_label",
-        "type": "text",
-        "label": "Password field label",
-        "default": "New password"
-      }, {
-        "id": "password_confirmation_label",
-        "type": "text",
-        "label": "Password confirmation field label",
-        "default": "Confirm new password"
-      }, {
-        "id": "change_my_password",
-        "type": "text",
-        "label": "Change my password",
-        "default": "Change my password"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}

--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -1,13 +1,11 @@
 {{ "account.css" | asset_url | stylesheet_tag }}
 
 <div class="account">
-  <h3 class="account__title">{{ section.settings.title }}</h3>
+  <h3 class="account__title">{{ "auth.sign_in.title" | user_t }}</h3>
 
-  {% if section.settings.description %}
-    <div class="account__divider">
-      {{ section.settings.description }}
-    </div>
-  {% endif %}
+  <div class="account__divider">
+    {{ "auth.sign_in.description" | user_t }}
+  </div>
 
   {%- if alert -%}
     <div class="account__alert account__alert--danger">{{ alert }}</div>
@@ -19,7 +17,7 @@
 
   {% form 'login' %}
     <div>
-      <label for="user_email" class="account-fieldset__label">{{ section.settings.email_label }}</label>
+      <label for="user_email" class="account-fieldset__label">{{ "auth.fields.email" | user_t }}</label>
       <input
         value="{{ form.email }}"
         class="account-fieldset__input"
@@ -32,7 +30,7 @@
     </div>
 
     <div>
-      <label for="user_password" class="account-fieldset__label">{{ section.settings.password_label }}</label>
+      <label for="user_password" class="account-fieldset__label">{{ "auth.fields.password" | user_t }}</label>
       <input
         value="{{ form.password }}"
         class="account-fieldset__input"
@@ -44,7 +42,7 @@
     </div>
 
     <div class="account__divider">
-      <a href="{{ routes.new_reset_password_url }}" class="account__link">{{ section.settings.reset_password_label }}</a>
+      <a href="{{ routes.new_reset_password_url }}" class="account__link">{{ "auth.forgot_password_button" | user_t }}</a>
     </div>
 
     <div class="account__divider">
@@ -52,18 +50,18 @@
         type="submit"
         class="account__button account__button--primary"
         name="commit"
-        value="{{ section.settings.button_login_label }}"
+        value="{{ "auth.sign_in_button" | user_t }}"
       >
     </div>
 
     <hr class="account__separator" />
 
     {%- if shop.allow_signup -%}
-      <a href="{{ routes.register_url }}" class="account__button account__button--secondary account__divider">{{ section.settings.create_account_label }}</a>
+      <a href="{{ routes.register_url }}" class="account__button account__button--secondary account__divider">{{ "auth.sign_in.create_account" | user_t }}</a>
     {%- endif -%}
 
     {%- if shop.allow_guest_checkout and guest_checkout_url -%}
-      <a href="{{ guest_checkout_url }}" class="account__button account__button--minimal">{{ section.settings.continue_as_guest_label }}</a>
+      <a href="{{ guest_checkout_url }}" class="account__button account__button--minimal">{{ "auth.sign_in.continue_as_guest" | user_t }}</a>
     {%- endif -%}
 
   {% endform %}
@@ -75,54 +73,6 @@
     "important": true,
     "unique": true,
     "templates": ["login"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      },
-      {
-        "id": "title",
-        "type": "text",
-        "label": "Title",
-        "default": "Log in"
-      },
-      {
-        "id": "description",
-        "type": "text",
-        "label": "Description",
-        "default": ""
-      },
-      {
-        "id": "email_label",
-        "type": "text",
-        "label": "Email field label",
-        "default": "Email"
-      }, {
-        "id": "password_label",
-        "type": "text",
-        "label": "Password field label",
-        "default": "Password"
-      }, {
-        "id": "button_login_label",
-        "type": "text",
-        "label": "Log in button label",
-        "default": "Log in"
-      }, {
-        "id": "create_account_label",
-        "type": "text",
-        "label": "Create account button label",
-        "default": "Create an account"
-      }, {
-        "id": "reset_password_label",
-        "type": "text",
-        "label": "Reset password link label",
-        "default": "Forgot your password?"
-      }, {
-        "id": "continue_as_guest_label",
-        "type": "text",
-        "label": "Continue as guest link label",
-        "default": "Continue as guest"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -1,11 +1,11 @@
 {{ "account.css" | asset_url | stylesheet_tag }}
 
 <div class="account">
-  <h3 class="account__title">{{ section.settings.title }}</h3>
+  <h3 class="account__title">{{ "auth.sign_up.title" | user_t }}</h3>
   <div class="account__divider">
-    {{ section.settings.login_description }}
+    {{ "auth.sign_up.already_have_an_account" | user_t }}
     <a class="account__link" href="{{ routes.login_url }}">
-      {{ section.settings.login_link_label }}
+      {{ "auth.sign_in_button" | user_t }}
     </a>
   </div>
 
@@ -15,7 +15,7 @@
 
   {% form 'register' %}
     <div class="{% if form.errors.name %}account-fieldset--error{% endif %}">
-      <label for="user_name" class="account-fieldset__label">{{ section.settings.name_label }}</label>
+      <label for="user_name" class="account-fieldset__label">{{ "auth.fields.full_name" | user_t }}</label>
       <input
         value="{{ form.name }}"
         placeholder=" "
@@ -29,7 +29,7 @@
     </div>
 
     <div class="{% if form.errors.email %}account-fieldset--error{% endif %}">
-      <label for="user_email" class="account-fieldset__label">{{ section.settings.email_label }}</label>
+      <label for="user_email" class="account-fieldset__label">{{ "auth.fields.email" | user_t }}</label>
       <input
         value="{{ form.email }}"
         placeholder=" "
@@ -41,15 +41,17 @@
       <div class="account__error-message">{{ form.errors.email }}</div>
     </div>
 
+    {%- assign password_label = "auth.fields.password" | user_t -%}
+    {%- assign password_confirmation_label = "auth.fields.password_confirmation" | user_t -%}
     {%- render 'form-password-session-pages',
         form: form,
         form_name: "register",
-        password_label: section.settings.password_label,
-        password_confirmation_label: section.settings.password_confirmation_label
+        password_label: password_label,
+        password_confirmation_label: password_confirmation_label
     -%}
 
     <div class="{% if form.errors.customer %}account-fieldset--error{% endif %} account__divider">
-      <label class="account-fieldset__static-label">{{ section.settings.account_type_label }}</label>
+      <label class="account-fieldset__static-label">{{ "auth.fields.legal_type" | user_t }}</label>
 
       <div class="account-type-options">
         <div class="account-type-options__first-option">
@@ -59,7 +61,7 @@
             id="user_legal_type_person"
             value="person"
             {% if form.legal_type == 'person' %}checked{% endif %}>
-          <label class="account-fieldset__radio-label" for="user_legal_type_person">{{ section.settings.private_label }}</label>
+          <label class="account-fieldset__radio-label" for="user_legal_type_person">{{ "auth.fields.legal_person" | user_t }}</label>
         </div>
 
         <div>
@@ -69,7 +71,7 @@
             id="user_legal_type_commercial"
             value="commercial"
             {% if form.legal_type == 'commercial' %}checked{% endif %}>
-          <label class="account-fieldset__radio-label" for="user_legal_type_commercial">{{ section.settings.company_label }}</label>
+          <label class="account-fieldset__radio-label" for="user_legal_type_commercial">{{ "auth.fields.legal_commercial" | user_t }}</label>
         </div>
       </div>
       <div class="account__error-message">{{ form.errors.customer }}</div>
@@ -83,12 +85,12 @@
         value="true"
         {% if form.agreement_accepted %}checked{% endif %}>
       <label for="user_agreement_accepted">
-        {{ section.settings.i_agree_label }}
+        {{ "auth.fields.accept_toc" | user_t }}
 
         <span class="account__agreement">
           <input type="checkbox" id="user_agreement_opener" style="display: none">
           <label for="user_agreement_opener" class="account__agreement-opener">
-            {{ section.settings.terms_and_agreements_label }}
+            {{ "auth.sign_up.terms_and_agreements" | user_t }}
           </label>
 
           <span class="account__agreement-modal bq-content rx-content" style="display: none">
@@ -101,7 +103,7 @@
 
                   <span class="account__agreement-buttons">
                     <label class="account__agreement-button account__button account__button--primary" for="user_agreement_opener">
-                      {{ section.settings.terms_and_agreements_accept_button_label }}
+                      {{ "auth.sign_up.agree" | user_t }}
                     </label>
                   </span>
                 </span>
@@ -117,7 +119,7 @@
       type="submit"
       class="account__button account__button--primary"
       name="commit"
-      value="{{ section.settings.button_sign_up_label }}"
+      value="{{ "auth.sign_up_button" | user_t }}"
     >
   {% endform %}
 </div>
@@ -128,84 +130,6 @@
     "important": true,
     "unique": true,
     "templates": ["register"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      },
-      {
-        "id": "title",
-        "type": "text",
-        "label": "Title",
-        "default": "Create an account"
-      },
-      {
-        "id": "login_description",
-        "type": "text",
-        "label": "Log in description",
-        "default": "Already have an account?"
-      },
-      {
-        "id": "login_link_label",
-        "type": "text",
-        "label": "Log in link label",
-        "default": "Log in"
-      }, {
-        "id": "name_label",
-        "type": "text",
-        "label": "Name field label",
-        "default": "Full name"
-      }, {
-        "id": "email_label",
-        "type": "text",
-        "label": "Email field label",
-        "default": "Email"
-      }, {
-        "id": "password_label",
-        "type": "text",
-        "label": "Password field label",
-        "default": "Password"
-      }, {
-        "id": "password_confirmation_label",
-        "type": "text",
-        "label": "Password confirmation field label",
-        "default": "Password confirmation"
-      }, {
-        "id": "account_type_label",
-        "type": "text",
-        "label": "Account type label",
-        "default": "Account type"
-      }, {
-        "id": "private_label",
-        "type": "text",
-        "label": "Private label",
-        "default": "Private"
-      }, {
-        "id": "company_label",
-        "type": "text",
-        "label": "Company label",
-        "default": "Company"
-      }, {
-        "id": "i_agree_label",
-        "type": "text",
-        "label": "I agree...",
-        "default": "I agree to the"
-      }, {
-        "id": "terms_and_agreements_label",
-        "type": "text",
-        "label": "Terms and agreements",
-        "default": "Terms and agreements"
-      }, {
-        "id": "terms_and_agreements_accept_button_label",
-        "type": "text",
-        "label": "Terms and agreements button (Modal window)",
-        "default": "Agree"
-      }, {
-        "id": "button_sign_up_label",
-        "type": "text",
-        "label": "Sign up button",
-        "default": "Sign up"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}

--- a/sections/reset-password-form.liquid
+++ b/sections/reset-password-form.liquid
@@ -3,20 +3,18 @@
 <div class="account">
   <a href="{{ routes.login_url }}" class="breadcrumbs">
     <i class="fa-regular fa-chevron-left breadcrumbs__chevron"></i>
-    {{ section.settings.back }}
+    {{ "auth.forgot_password.back" | user_t }}
   </a>
 
-  <h3 class="account__title">{{ section.settings.title }}</h3>
+  <h3 class="account__title">{{ "auth.forgot_password.title" | user_t }}</h3>
 
-  {% if section.settings.description %}
-    <div class="account__divider">
-      {{ section.settings.description }}
-    </div>
-  {% endif %}
+  <div class="account__divider">
+    {{ "auth.forgot_password.description" | user_t }}
+  </div>
 
   {% form 'reset_password' %}
     <div class="account__divider--small {% if form.errors.email %}account-fieldset--error{% endif %}">
-      <label for="user_email" class="account-fieldset__label">{{ section.settings.email_label }}</label>
+      <label for="user_email" class="account-fieldset__label">{{ "auth.fields.email" | user_t }}</label>
       <input
         value="{{ form.email }}"
         autofocus="autofocus"
@@ -33,7 +31,7 @@
       type="submit"
       class="account__button account__button--primary"
       name="commit"
-      value="{{ section.settings.reset_password_button_label }}"
+      value="{{ "auth.forgot_password.reset_password" | user_t }}"
     >
   {% endform %}
 </div>
@@ -44,39 +42,6 @@
     "important": true,
     "unique": true,
     "templates": ["reset-password"],
-    "settings": [
-      {
-        "type": "header",
-        "content": "Translations"
-      },
-      {
-        "id": "back",
-        "type": "text",
-        "label": "Back link",
-        "default": "Back"
-      },
-      {
-        "id": "title",
-        "type": "text",
-        "label": "Title",
-        "default": "Reset your password"
-      },
-      {
-        "id": "description",
-        "type": "text",
-        "label": "Description",
-        "default": "Enter your email address below and we will send you an email with a link to create a new password."
-      }, {
-        "id": "email_label",
-        "type": "text",
-        "label": "Email field label",
-        "default": "Email"
-      }, {
-        "id": "reset_password_button_label",
-        "type": "text",
-        "label": "Reset password button label",
-        "default": "Reset password"
-      }
-    ]
+    "settings": []
   }
 {% endschema %}


### PR DESCRIPTION
## Why

Account-related sections (login, register, reset/edit password, invite, activate) were using section settings for translations, which prevented proper multi-language support. This replaces all those section settings with the `user_t` filter, aligning auth sections with the same translation approach used throughout the rest of the theme.

The translation-specific settings blocks have been removed from all affected section schemas, simplifying the schema definitions.

## Link

Partially fix [Missing translation](https://linear.app/booqable/issue/SC-2323/missing-translation)

## Media

<img width="555" height="409" alt="Captura de pantalla 2026-03-10 a las 12 36 14" src="https://github.com/user-attachments/assets/35feeb33-89e3-4171-bb1d-3c0bfabc76f7" />
