### PR TITLE
Fix: Show hamburger menu on all pages, not just the homepage

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -403,7 +403,7 @@
   font-weight: 300;
 }
 
-.header-floating-menu, 
+.header-floating-menu,
 .collection-floating-menu {
   display: none;
 }
@@ -485,6 +485,16 @@
   }
 }
 
+@media (min-width: 991px) {
+  .header__wrapper.header__wrapper--with-menu {
+    grid-template-columns: 1fr max-content;
+  }
+
+  .header__wrapper.header__wrapper--with-menu.header__wrapper--with-mini-cart {
+    grid-template-rows: 1fr max-content 50px;
+  }
+}
+
 @media (max-width: 991px) {
   .header__nav--desktop {
     display: none;
@@ -533,6 +543,7 @@
 
   .header-search__wrapper .header-search__input-wrapper {
     width: 100%;
+    max-width: 260px;
   }
 
   .header-search #floating-search:checked ~ .header-search__wrapper {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -2,7 +2,6 @@
 {{ "list-menu.css" | asset_url | stylesheet_tag }}
 
 {% assign app = section.blocks | where: "type", "app" | first -%}
-{% assign current_url = request_fullpath | strip %}
 
 {% if app %}
   {{ "app.css" | asset_url | stylesheet_tag }}
@@ -80,16 +79,16 @@
 
   @media (max-width: 990px) {
     .header .header__wrapper--with-menu, .header .header__wrapper--with-mini-cart {
-      grid-template-columns: 1fr repeat({% if current_url == routes.root_url %}3 {%  else  %}2 {% endif %}, 50px);
+      grid-template-columns: 1fr repeat(2, 50px);
     }
 
     .header .header__wrapper--with-menu.header__wrapper--with-mini-cart {
-      grid-template-columns: 1fr repeat({% if current_url == routes.root_url %}3 {%  else  %}2 {% endif %}, 50px);
+      grid-template-columns: 1fr repeat(3, 50px);
     }
   }
 </style>
 
-<div class="header__wrapper{% if section.settings.menu != blank %} header__wrapper--with-menu{% endif %}{% if show_mini_cart %} header__wrapper--with-mini-cart{% else %} header__wrapper--without-mini-cart{% endif %}">
+<div class="header__wrapper header__wrapper--with-menu{% if show_mini_cart %} header__wrapper--with-mini-cart{% else %} header__wrapper--without-mini-cart{% endif %}">
   <div class="header__link-container">
     <a href="{{ routes.root_url }}" class="header__link">
       {% if section.settings.logo.url != blank %}
@@ -193,13 +192,11 @@
       <i class="fa-regular fa-spinner-third fa-spin"></i>
     </div>
   {% endif %}
-  {% if current_url == routes.root_url %}
-    <div class="collection-floating-menu">
-      <button class="header-collection-floating-menu__trigger" onclick="handleOpenCollectionMenu()">
-        <i class="fa-regular fa-bars header-collection-floating-menu__icon open"></i>
-      </button>
-    </div>
-  {% endif %}
+  <div class="collection-floating-menu">
+    <button class="header-collection-floating-menu__trigger" onclick="handleOpenCollectionMenu()">
+      <i class="fa-regular fa-bars header-collection-floating-menu__icon open"></i>
+    </button>
+  </div>
   {% if section.settings.menu != blank %}
     <div class="header-floating-menu">
       <input type="checkbox" id="floating-menu-trigger">


### PR DESCRIPTION
The hamburger menu (collection floating menu) was conditionally rendered only when the user was on the root URL (/), causing it to disappear on all other pages like product listings, booking pages, and account pages.

This fix removes the URL-based condition so the menu renders on every page. The grid layout logic was also simplified — instead of dynamically computing column count based on the current URL, the layout now uses fixed grid values per breakpoint, with proper desktop styles added to handle the `header__wrapper--with-menu` modifier consistently.