### PR TITLE
Add base errors to registration form

### DIFF
--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -14,6 +14,10 @@
   {%- endif -%}
 
   {% form 'register' %}
+    {%- if form.errors.base != blank -%}
+      <div class="account__alert account__alert--danger">{{ form.errors.base }}</div>
+    {%- endif -%}
+
     <div class="{% if form.errors.name %}account-fieldset--error{% endif %}">
       <label for="user_name" class="account-fieldset__label">{{ "auth.fields.full_name" | user_t }}</label>
       <input


### PR DESCRIPTION
In [this PR](https://github.com/booqable/booqable/pull/17543/changes) we introduced reCaptcha to registration form which can add an error to the base of a registration form.
This PR makes sure those errors are shown in the UI.

## Media

<img width="1311" height="887" alt="Screenshot 2026-06-11 at 14 58 40" src="https://github.com/user-attachments/assets/893cbff9-a62d-43f7-bc4b-da0e52056cab" />
