### PR TITLE
Header: Hide collection menu button when no collections exist

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -2,6 +2,7 @@
 {{ "list-menu.css" | asset_url | stylesheet_tag }}
 
 {% assign app = section.blocks | where: "type", "app" | first -%}
+{%  assign collections_size = non_system_collections | size %}
 
 {% if app %}
   {{ "app.css" | asset_url | stylesheet_tag }}
@@ -79,11 +80,11 @@
 
   @media (max-width: 990px) {
     .header .header__wrapper--with-menu, .header .header__wrapper--with-mini-cart {
-      grid-template-columns: 1fr repeat(2, 50px);
+      grid-template-columns: 1fr repeat({% if collections_size > 0 %}2{% else %}1{% endif %}, 50px);
     }
 
     .header .header__wrapper--with-menu.header__wrapper--with-mini-cart {
-      grid-template-columns: 1fr repeat(3, 50px);
+      grid-template-columns: 1fr repeat({% if collections_size > 0 %}3{% else %}2{% endif %}, 50px);
     }
   }
 </style>
@@ -192,11 +193,13 @@
       <i class="fa-regular fa-spinner-third fa-spin"></i>
     </div>
   {% endif %}
-  <div class="collection-floating-menu">
-    <button class="header-collection-floating-menu__trigger" onclick="handleOpenCollectionMenu()">
-      <i class="fa-regular fa-bars header-collection-floating-menu__icon open"></i>
-    </button>
-  </div>
+  {% if collections_size > 0 %}
+    <div class="collection-floating-menu">
+      <button class="header-collection-floating-menu__trigger" onclick="handleOpenCollectionMenu()">
+        <i class="fa-regular fa-bars header-collection-floating-menu__icon open"></i>
+      </button>
+    </div>
+  {% endif %}
   {% if section.settings.menu != blank %}
     <div class="header-floating-menu">
       <input type="checkbox" id="floating-menu-trigger">


### PR DESCRIPTION
The collection floating menu button was always rendered in the header regardless of whether any collections existed.

The button is now conditionally rendered only when `collections_size > 0`, and the mobile grid column counts are adjusted accordingly — dropping by one column when the collection menu is absent.

[LINK](https://linear.app/booqable/issue/SC-2824/hamburger-menu-not-clickable-or-missing-on-mobile)

<img width="1528" height="562" alt="Captura de pantalla 2026-06-19 a las 9 11 38" src="https://github.com/user-attachments/assets/1917dfd9-04d4-4514-828a-79d3717cb37c" />
<img width="393" height="871" alt="Captura de pantalla 2026-06-19 a las 9 12 17" src="https://github.com/user-attachments/assets/f7f33b82-c6d5-4ad7-a79d-fb313906427b" />
