### PR TITLE
Images: Fix dynamic size loading

### DIFF
--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -74,8 +74,8 @@
                   {{ image | image_tag:
                     loading: image_loading,
                     class: 'product__image',
-                    widths: '500, 700',
-                    sizes: '(max-width: 489px) 700px, 500px',
+                    widths: '250, 500, 800',
+                    sizes: '(max-width: 489px) calc(100vw - 66px), 250px',
                     focal: focal,
                     alt: item.name
                   }}

--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -74,8 +74,8 @@
                   {{ image | image_tag:
                     loading: image_loading,
                     class: 'product__image',
-                    widths: '250, 500, 800',
-                    sizes: '(max-width: 489px) calc(100vw - 66px), 250px',
+                    widths: '300, 600, 900',
+                    sizes: '(max-width: 489px) calc(100vw - 66px), 286px',
                     focal: focal,
                     alt: item.name
                   }}

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -37,8 +37,8 @@
             loading: 'lazy',
             class: 'product__image',
             alt: result.name,
-            widths: '250, 500, 800',
-            sizes: '(max-width: 489px) calc(100vw - 66px), 250px',
+            widths: '300, 600, 900',
+            sizes: '(max-width: 489px) calc(100vw - 66px), 286px',
             focal: focal
           }}{% endif %}</a>
           {{ result | product_availability }}

--- a/sections/search.liquid
+++ b/sections/search.liquid
@@ -37,8 +37,8 @@
             loading: 'lazy',
             class: 'product__image',
             alt: result.name,
-            widths: '600, 750',
-            sizes: '(max-width: 490px) 750px, 600px',
+            widths: '250, 500, 800',
+            sizes: '(max-width: 489px) calc(100vw - 66px), 250px',
             focal: focal
           }}{% endif %}</a>
           {{ result | product_availability }}


### PR DESCRIPTION
## Why

Current image sizes configuration is not correct. We assumed that we need to declare double size images in the `sizes` in order for retina pages to have high enough resolution - this is not correct. Browser will automatically load double size image depending on the screen density.

This PR updates the `sizes` settings to more conservative values, but increases the maximum image width we provide in order to enable loading higher resolution images when needed.


## Media
<img width="965" height="851" alt="Screenshot 2026-08-10 at 15 03 37" src="https://github.com/user-attachments/assets/37d868d6-2136-454e-9565-658e0b4a5709" />
